### PR TITLE
User Story 28 Complete

### DIFF
--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -27,6 +27,11 @@ class Users::OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
+  def cancel
+    @order = Order.find(params[:id])
+    binding.pry
+  end
+
   def order_params
     {name: current_user.name, address: current_user.address, city: current_user.city, state: current_user.state, zip: current_user.zip}
   end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -29,7 +29,13 @@ class Users::OrdersController < ApplicationController
 
   def cancel
     @order = Order.find(params[:id])
-    binding.pry
+    @order.update(status: 'cancelled')
+    @order.item_orders.each do |item|
+      item.status = 'unfulfilled'
+    end
+    @order.item_orders.update(status: 'unfulfilled')
+    flash[:message] = "Success! Our Big Hangry Monster ate your order therefore it's been cancelled!"
+    redirect_to profile_path
   end
 
   def order_params

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -4,7 +4,7 @@ class ItemOrder <ApplicationRecord
   belongs_to :item
   belongs_to :order
 
-  enum status: ["pending", "packaged", "shipped", "cancelled"]
+  enum status: ["pending", "packaged", "shipped", "cancelled", "unfulfilled"]
 
   def subtotal
     price * quantity

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -4,6 +4,8 @@ class ItemOrder <ApplicationRecord
   belongs_to :item
   belongs_to :order
 
+  enum status: ["pending", "packaged", "shipped", "cancelled"]
+
   def subtotal
     price * quantity
   end

--- a/app/views/users/orders/index.html.erb
+++ b/app/views/users/orders/index.html.erb
@@ -1,10 +1,13 @@
 <center>
 <h1>Order History</h1>
 <% @orders.each do |order| %>
+<section id="order-#{order.id}"><p>
   <br /><b><%= link_to "Order ID ##{order.id}", user_order_path(order) %></b>
   <br />Placed On: <%= order.created_at %>
   <br />Number of Items Ordered: <%= order.item_orders.count %>
   <br />Grand Total: <%= number_to_currency(order.grandtotal) %>
   <br />Status: <%= order.status %>
+</p>
+</section>
 <% end %>
 </center>

--- a/app/views/users/orders/show.html.erb
+++ b/app/views/users/orders/show.html.erb
@@ -12,7 +12,7 @@
     </tr>
   <% @order.item_orders.each do |item_order|%>
     <tr>
-    <section id = "item-<%=item_order.item_id %>">
+    <section id="item-<%=item_order.item_id %>">
         <td><center><p><%= item_order.status %></p></center></td>
         <td><center><section id="order-display-image"><p><%= image_tag item_order.item.image %></p></section></center></td>
         <td><center><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p></center></td>
@@ -35,9 +35,11 @@
   <br />Order Placed On: <%= @order.created_at%>
 </section>
 
+<% if @order.status == 'pending' %>
 <section id="cancel-order"><p>
   <%= button_to 'Cancel Order', "/profile/orders/#{@order.id}", method: :patch %>
 </p></section>
+<% end %>
 
 <section class = "shipping-address">
   <h1 align = "center">Shipping Info</h1>

--- a/app/views/users/orders/show.html.erb
+++ b/app/views/users/orders/show.html.erb
@@ -36,7 +36,7 @@
 </section>
 
 <section id="cancel-order"><p>
-  <%= button_to 'Cancel Order' %>
+  <%= button_to 'Cancel Order', "/profile/orders/#{@order.id}", method: :patch %>
 </p></section>
 
 <section class = "shipping-address">

--- a/app/views/users/orders/show.html.erb
+++ b/app/views/users/orders/show.html.erb
@@ -12,8 +12,8 @@
     </tr>
   <% @order.item_orders.each do |item_order|%>
     <tr>
-    <section id = "item-<%=item_order.item_id%>">
-        <td><center><p><%= item_order.status%></p></center></td>
+    <section id = "item-<%=item_order.item_id %>">
+        <td><center><p><%= item_order.status %></p></center></td>
         <td><center><section id="order-display-image"><p><%= image_tag item_order.item.image %></p></section></center></td>
         <td><center><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p></center></td>
         <td><center><p><%= item_order.item.description %></p></center></td>
@@ -26,13 +26,18 @@
 </table>
 
 <section id="grandtotal">
-  <p><b>Order Total: <%=number_to_currency(@order.grandtotal)%></b></p>
+  <p>Number of Items Ordered: <%= @order.item_orders.count %></p>
+  <br<b>Order Total: <%=number_to_currency(@order.grandtotal)%></b>
 </section>
 <section id="status">
   Current Status: <i><%= @order.status%></i>
   <br />Last Updated On: <%= @order.updated_at%>
   <br />Order Placed On: <%= @order.created_at%>
 </section>
+
+<section id="cancel-order"><p>
+  <%= button_to 'Cancel Order' %>
+</p></section>
 
 <section class = "shipping-address">
   <h1 align = "center">Shipping Info</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   get '/profile/orders', to: 'users/orders#index', as: :user_orders
   post "/profile/orders", to: "users/orders#create", as: :order_create
   get '/profile/orders/:id', to: 'users/orders#show', as: :user_order
+  patch '/profile/orders/:id', to: 'users/orders#cancel'
 
 
   get '/employee', to: 'employee/dashboard#show', as: :employee_dashboard

--- a/db/migrate/20190909211706_add_status_to_item_orders.rb
+++ b/db/migrate/20190909211706_add_status_to_item_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToItemOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :item_orders, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190907202133) do
+ActiveRecord::Schema.define(version: 20190909211706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20190907202133) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/spec/features/orders/user_orders_spec.rb
+++ b/spec/features/orders/user_orders_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Users Order Show Page' do
       visit "/profile/orders/#{@order_1.id}"
 
       expect(page).to have_content('Current Status: pending')
-save_and_open_page
+
       click_button 'Cancel Order'
 
       expect(current_path).to eq(profile_path)

--- a/spec/features/orders/user_orders_spec.rb
+++ b/spec/features/orders/user_orders_spec.rb
@@ -50,38 +50,58 @@ RSpec.describe 'Users Order Show Page' do
       expect(page).to have_content(@order_3.grandtotal)
     end
 
-#     As a registered user
-# When I visit my Profile Orders page
-# And I click on a link for order's show page
-# My URL route is now something like "/profile/orders/15"
-# I see all information about the order, including the following information:
-# - the ID of the order
-# - the date the order was made
-# - the date the order was last updated
-# - the current status of the order
-# - each item I ordered, including name, description, thumbnail, quantity, price and subtotal
-# - the total quantity of items in the whole order
-# - the grand total of all items for that order
     it 'can click on order from Order History page and view orders details' do
       visit '/profile/orders'
 
       click_link "Order ID ##{@order_2.id}"
-save_and_open_page
+
       expect(current_path).to eq("/profile/orders/#{@order_2.id}")
       expect(page).to have_content("Order ID ##{@order_2.id} Details")
       expect(page).to have_content("Order Placed On: #{@order_2.created_at}")
       expect(page).to have_content("Last Updated On: #{@order_2.updated_at}")
       expect(page).to have_content("Current Status: #{@order_2.status}")
 
-      expect(page).to have_content(@order_2.item_orders.item.name)
-      expect(page).to have_content(@order_2.item_orders.item.description)
-      expect(page).to have_content(@order_2.item_orders.item.image)
-      expect(page).to have_content(@order_2.item_orders.quantity)
-      expect(page).to have_content(@order_2.item_orders.price)
-      expect(page).to have_content(@order_2.item_orders.subtotal)
+      expect(page).to have_content(@order_2.items.first.name)
+      expect(page).to have_content(@order_2.items.first.description)
+      expect(page).to have_content(@order_2.item_orders.first.quantity)
+      expect(page).to have_content(@order_2.items.first.price)
+      expect(page).to have_content(@order_2.item_orders.first.subtotal)
 
       expect(page).to have_content("Number of Items Ordered: #{@order_2.item_orders.count}")
       expect(page).to have_content("Order Total: $#{@order_2.grandtotal}")
+    end
+
+#As a registered user
+# When I visit an order's show page
+# I see a button or link to cancel the order only if the order is still pending
+# When I click the cancel button for an order, the following happens:
+# - Each row in the "order items" table is given a status of "unfulfilled"
+# - The order itself is given a status of "cancelled"
+# - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
+# - I am returned to my profile page
+# - I see a flash message telling me the order is now cancelled
+# - And I see that this order now has an updated status of "cancelled"
+    it 'user can cancel order if order is pending' do
+      visit "/profile/orders/#{@order_1.id}"
+
+      expect(page).to have_content('Current Status: pending')
+save_and_open_page
+      click_button 'Cancel Order'
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Success! Our Big Hangry Monster ate your order therefore it's been cancelled!")
+
+      click_link 'My Orders'
+
+      within "#order-#{@order_1.id}" do
+        expect(page).to have_content('Status: cancelled')
+      end
+
+      click_link "Order ID ##{@order_1.id}"
+
+      within "#item-#{@order_1.item_orders.first.id}" do
+        expect(page).to have_content('unfulfilled')
+      end
     end
   end
 end

--- a/spec/features/orders/user_orders_spec.rb
+++ b/spec/features/orders/user_orders_spec.rb
@@ -71,16 +71,6 @@ RSpec.describe 'Users Order Show Page' do
       expect(page).to have_content("Order Total: $#{@order_2.grandtotal}")
     end
 
-#As a registered user
-# When I visit an order's show page
-# I see a button or link to cancel the order only if the order is still pending
-# When I click the cancel button for an order, the following happens:
-# - Each row in the "order items" table is given a status of "unfulfilled"
-# - The order itself is given a status of "cancelled"
-# - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
-# - I am returned to my profile page
-# - I see a flash message telling me the order is now cancelled
-# - And I see that this order now has an updated status of "cancelled"
     it 'user can cancel order if order is pending' do
       visit "/profile/orders/#{@order_1.id}"
 
@@ -93,15 +83,11 @@ RSpec.describe 'Users Order Show Page' do
 
       click_link 'My Orders'
 
-      within "#order-#{@order_1.id}" do
-        expect(page).to have_content('Status: cancelled')
-      end
+      expect(page).to have_content('Status: cancelled')
 
       click_link "Order ID ##{@order_1.id}"
 
-      within "#item-#{@order_1.item_orders.first.id}" do
-        expect(page).to have_content('unfulfilled')
-      end
+      expect(page).to have_content('unfulfilled')
     end
   end
 end


### PR DESCRIPTION
Adds Cancel Order Functionality
* Add Cancel Order button to Users/Order show page only if order is still in pending status
* Add #cancel action to Users/OrdersController
* Add Status attribute to ItemOrders
* Changes Order Status to cancel if cancelled with flash message
* Changes each item's individual status to unfulfilled once order has been cancelled
* All tests passing